### PR TITLE
UID2-7015: add unit tests for attestation-api

### DIFF
--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -40,6 +40,5 @@ jobs:
       java_version: ${{ inputs.java_version }}
       publish_vulnerabilities: ${{ inputs.publish_vulnerabilities }}
       vulnerability_failure_severity: ${{ inputs.vulnerability_failure_severity }}
-      skip_tests: true # No tests are present in this repository
       merge_environment: ${{ github.ref_protected && 'ci-auto-merge' || '' }}
     secrets: inherit

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -7,4 +7,3 @@ jobs:
     secrets: inherit
     with:
       java_version: 21
-      skip_tests: true # No tests are present in this repository

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,12 @@
   </properties>
 
   <dependencies>
-
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13.2</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <distributionManagement>
     <snapshotRepository>

--- a/src/test/java/com/uid2/enclave/AttestationExceptionTest.java
+++ b/src/test/java/com/uid2/enclave/AttestationExceptionTest.java
@@ -1,0 +1,20 @@
+package com.uid2.enclave;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class AttestationExceptionTest {
+    @Test
+    public void testConstructWithMessage() {
+        AttestationException e = new AttestationException("boom");
+        assertEquals("boom", e.getMessage());
+        assertNull(e.getCause());
+    }
+
+    @Test
+    public void testConstructWithCause() {
+        Throwable cause = new RuntimeException("root");
+        AttestationException e = new AttestationException(cause);
+        assertSame(cause, e.getCause());
+    }
+}

--- a/src/test/java/com/uid2/enclave/AttestationExceptionTest.java
+++ b/src/test/java/com/uid2/enclave/AttestationExceptionTest.java
@@ -16,5 +16,6 @@ public class AttestationExceptionTest {
         Throwable cause = new RuntimeException("root");
         AttestationException e = new AttestationException(cause);
         assertSame(cause, e.getCause());
+        assertNotNull(e.getMessage());
     }
 }

--- a/src/test/java/com/uid2/enclave/IAttestationProviderTest.java
+++ b/src/test/java/com/uid2/enclave/IAttestationProviderTest.java
@@ -1,12 +1,25 @@
 package com.uid2.enclave;
 
 import org.junit.Test;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 public class IAttestationProviderTest {
     @Test
     public void testIsReadyDefaultsTrue() {
         IAttestationProvider p = (publicKey, userData) -> new byte[0];
         assertTrue(p.isReady());
+    }
+
+    @Test
+    public void testGetAttestationRequestReturnsBytes() throws AttestationException {
+        byte[] expected = new byte[]{0x01, 0x02};
+        IAttestationProvider p = (publicKey, userData) -> expected;
+        assertArrayEquals(expected, p.getAttestationRequest(new byte[0], new byte[0]));
+    }
+
+    @Test(expected = AttestationException.class)
+    public void testGetAttestationRequestCanThrowAttestationException() throws AttestationException {
+        IAttestationProvider p = (publicKey, userData) -> { throw new AttestationException("fail"); };
+        p.getAttestationRequest(new byte[0], new byte[0]);
     }
 }

--- a/src/test/java/com/uid2/enclave/IAttestationProviderTest.java
+++ b/src/test/java/com/uid2/enclave/IAttestationProviderTest.java
@@ -1,0 +1,12 @@
+package com.uid2.enclave;
+
+import org.junit.Test;
+import static org.junit.Assert.assertTrue;
+
+public class IAttestationProviderTest {
+    @Test
+    public void testIsReadyDefaultsTrue() {
+        IAttestationProvider p = (publicKey, userData) -> new byte[0];
+        assertTrue(p.isReady());
+    }
+}

--- a/src/test/java/com/uid2/enclave/IOperatorKeyRetrieverTest.java
+++ b/src/test/java/com/uid2/enclave/IOperatorKeyRetrieverTest.java
@@ -1,0 +1,12 @@
+package com.uid2.enclave;
+
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+
+public class IOperatorKeyRetrieverTest {
+    @Test
+    public void testRetrieveReturnsKey() {
+        IOperatorKeyRetriever retriever = () -> "test-key";
+        assertEquals("test-key", retriever.retrieve());
+    }
+}


### PR DESCRIPTION
## Summary
- Add JUnit 4.13.2 test dependency to pom.xml
- Add unit tests for `AttestationException` (2 tests) and `IAttestationProvider.isReady()` default (1 test)
- Remove `skip_tests: true` from build-and-test and build-and-publish workflows so CI runs `mvn test` on PR and publish

## Test plan
- [ ] CI build-and-test workflow runs and passes (3 tests)
- [ ] No other `with:` inputs removed from workflows

Jira: UID2-7015