### PR TITLE
UID2-7426: add check_jira_key required-status-check caller

### DIFF
--- a/.github/workflows/check-jira-key.yaml
+++ b/.github/workflows/check-jira-key.yaml
@@ -1,6 +1,3 @@
-# Roll out to each in-scope IABTechLab uid2* repo as .github/workflows/check-jira-key.yaml
-# once uid2-shared-actions #254 is merged AND a release has moved the v3 tag to include
-# actions/check_jira_key. Non-blocking until the terraform required_status_checks rule is flipped on.
 name: Check Jira Key
 on:
   pull_request:
@@ -11,8 +8,8 @@ permissions:
   pull-requests: read
 
 jobs:
-  # Job name PINNED to `check_jira_key` so every repo produces the same status-check context
-  # ("check_jira_key") — one terraform required_status_checks entry matches all repos (UID2-7426).
+  # Job name pinned to `check_jira_key` so every gated repo yields the same status-check context
+  # for a single terraform required_status_checks entry (UID2-7426).
   check_jira_key:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/check-jira-key.yaml
+++ b/.github/workflows/check-jira-key.yaml
@@ -1,0 +1,19 @@
+# Roll out to each in-scope IABTechLab uid2* repo as .github/workflows/check-jira-key.yaml
+# once uid2-shared-actions #254 is merged AND a release has moved the v3 tag to include
+# actions/check_jira_key. Non-blocking until the terraform required_status_checks rule is flipped on.
+name: Check Jira Key
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  # Job name PINNED to `check_jira_key` so every repo produces the same status-check context
+  # ("check_jira_key") — one terraform required_status_checks entry matches all repos (UID2-7426).
+  check_jira_key:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: IABTechLab/uid2-shared-actions/actions/check_jira_key@v3


### PR DESCRIPTION
## What

Adds `.github/workflows/check-jira-key.yaml` — the caller for the `check_jira_key` required-status-check (UID2-7426). **First of ~24 identical rollouts**, opened alone for review before fanning out to the rest.

## Behaviour

- Runs on `pull_request` (opened / edited / synchronize / reopened) and calls `IABTechLab/uid2-shared-actions/actions/check_jira_key@v3`.
- Fails a PR unless the squash commit that will land carries a `UID2-<n>` key or a reasoned `[no-jira - reason: <reason>]` opt-out (mirrors the native ruleset on the enterprise orgs; IABTechLab is team-plan so the native rule is inert there).
- **Non-blocking for now** — the check runs and reports, but isn't a *required* check until the terraform `required_status_checks` rule is flipped on (separate step, after a bake).
- Job name pinned to `check_jira_key` so every repo yields the same status-check context → one terraform required-check entry matches all 24.

## ⚠️ Do not merge yet

Merge only **after** `uid2-shared-actions` [#254](https://github.com/IABTechLab/uid2-shared-actions/pull/254) is merged **and** a release has moved the `v3` tag to include `actions/check_jira_key`. Otherwise, once this lands on `main`, future PRs here would fail to resolve the action at `@v3`.

(Safe to leave open in the meantime: `pull_request` workflows run from the **base** branch, which doesn't have this file yet, so the check does **not** run on this PR itself.)

## Rollout

Once this shape is approved, the identical file goes to the other 23 in-scope IABTechLab `uid2*` repos.
